### PR TITLE
fix: update target to es2022

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
-    "lib": ["es2020", "DOM"],
+    "lib": ["es2022", "DOM"],
     "module": "nodenext",
     "moduleResolution": "nodenext",
-    "target": "es2020",
+    "target": "es2022",
     "resolveJsonModule": true,
     "checkJs": true,
     "allowJs": true,


### PR DESCRIPTION
Needed for example for `Array.prototype.at`

With a few exceptions, all features of ES2022 are supported in versions of Node that we support: https://node.green/